### PR TITLE
🔄 Refactor OpenAI function calling and add extension method

### DIFF
--- a/dotnet/samples/KernelSyntaxExamples/Example59_OpenAIFunctionCalling.cs
+++ b/dotnet/samples/KernelSyntaxExamples/Example59_OpenAIFunctionCalling.cs
@@ -51,7 +51,7 @@ public static class Example59_OpenAIFunctionCalling
         // Create kernel with chat completions service
         IKernel kernel = new KernelBuilder()
             .WithLoggerFactory(ConsoleLogger.LoggerFactory)
-            .WithOpenAIChatCompletionService(TestConfiguration.OpenAI.ChatModelId, TestConfiguration.OpenAI.ApiKey, serviceId: "chat")
+            .WithOpenAIChatCompletionService("gpt-3.5-turbo-0613", TestConfiguration.OpenAI.ApiKey, serviceId: "chat")
             //.WithAzureChatCompletionService(TestConfiguration.AzureOpenAI.ChatDeploymentName, TestConfiguration.AzureOpenAI.Endpoint, TestConfiguration.AzureOpenAI.ApiKey, serviceId: "chat")
             .Build();
 

--- a/dotnet/src/Connectors/Connectors.AI.OpenAI/AzureSdk/ClientBase.cs
+++ b/dotnet/src/Connectors/Connectors.AI.OpenAI/AzureSdk/ClientBase.cs
@@ -403,7 +403,8 @@ public abstract class ClientBase
 
         if (validRole != ChatRole.User &&
             validRole != ChatRole.System &&
-            validRole != ChatRole.Assistant)
+            validRole != ChatRole.Assistant &&
+            validRole != ChatRole.Function)
         {
             throw new ArgumentException($"Invalid chat message author role: {role}");
         }

--- a/dotnet/src/Connectors/Connectors.AI.OpenAI/ChatCompletionExtensions.cs
+++ b/dotnet/src/Connectors/Connectors.AI.OpenAI/ChatCompletionExtensions.cs
@@ -1,10 +1,12 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
+using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.SemanticKernel;
+using Microsoft.SemanticKernel.Connectors.AI.OpenAI;
 using Microsoft.SemanticKernel.Connectors.AI.OpenAI.AzureSdk;
 using Microsoft.SemanticKernel.Orchestration;
-using Microsoft.SemanticKernel.SkillDefinition;
 
 #pragma warning disable IDE0130 // Namespace does not match folder structure
 namespace Microsoft.SemanticKernel.AI.ChatCompletion;
@@ -25,36 +27,56 @@ public static class ChatCompletionExtensions
     /// <param name="cancellationToken">The asynchronous cancellation token (optional).</param>
     /// <remarks>This extension does not support multiple prompt results (only the first will be returned).</remarks>
     /// <returns>A task representing the generated chat message in string format.</returns>
-    public static async Task<string> GenerateMessageWithFunctionsAsync(
+    public static async Task<ChatHistory> GenerateChatHistoryWithFunctionsAsync(
         this IChatCompletion chatCompletion,
         ChatHistory chat,
         IKernel kernel,
-        ChatRequestSettings? requestSettings = null,
+        AIRequestSettings? requestSettings = null,
         CancellationToken cancellationToken = default)
     {
-        IReadOnlySkillCollection skillCollection = kernel.Skills;
-        OpenAIChatRequestSettings chatRequestSettings = requestSettings as OpenAIChatRequestSettings ?? new();
-        chatRequestSettings.Functions = skillCollection.GetFunctionsView().ToOpenAIFunctions();
+        ChatHistory returnMessages = chat;
+        IReadOnlyFunctionCollection functionCollection = kernel.Functions;
+        OpenAIRequestSettings chatRequestSettings = requestSettings as OpenAIRequestSettings ?? new();
+        chatRequestSettings.Functions = functionCollection.GetFunctionViews().Select(functionView => functionView.ToOpenAIFunction()).ToList();
 
+        var chatMessages = await chatCompletion.GenerateChatHistoryWithFunctionsAsync(chat, kernel, functionCollection, chatRequestSettings, cancellationToken).ConfigureAwait(false);
+        returnMessages.Messages.AddRange(chatMessages.Messages);
+        return returnMessages;
+    }
+
+    private static async Task<ChatHistory> GenerateChatHistoryWithFunctionsAsync(
+        this IChatCompletion chatCompletion,
+        ChatHistory chat,
+        IKernel kernel,
+        IReadOnlyFunctionCollection functionCollection,
+        OpenAIRequestSettings chatRequestSettings,
+        CancellationToken cancellationToken = default)
+    {
+        ChatHistory returnMessages = chat;
         var chatResults = await chatCompletion.GetChatCompletionsAsync(chat, chatRequestSettings, cancellationToken).ConfigureAwait(false);
         var firstChatMessage = await chatResults[0].GetChatMessageAsync(cancellationToken).ConfigureAwait(false);
+        returnMessages.Messages.Add(firstChatMessage);
 
-        OpenAIFunctionResult? functionResult = chatResults[0].GetFunctionResult();
-        if (functionResult is not null)
+        OpenAIFunctionResponse? functionResponse = chatResults[0].GetFunctionResponse();
+        if (functionResponse is not null)
         {
-            if (skillCollection.TryGetFunction(functionResult.PluginName, functionResult.FunctionName, out var function))
+            if (functionCollection.TryGetFunction(functionResponse.PluginName, functionResponse.FunctionName, out var function))
             {
                 ContextVariables context = new();
-                foreach (var parameter in functionResult.Parameters)
+                foreach (var parameter in functionResponse.Parameters)
                 {
                     // Add parameter to context
                     context.Set(parameter.Key, parameter.Value.ToString());
                 }
 
-                return (await kernel.RunAsync(function, context, cancellationToken).ConfigureAwait(false)).Result;
+                var functionResult = await kernel.RunAsync(function, context, cancellationToken).ConfigureAwait(false);
+                returnMessages.AddMessage(AuthorRole.Function, functionResult.GetValue<string>() ?? string.Empty);
+
+                var newMesages = await chatCompletion.GenerateChatHistoryWithFunctionsAsync(returnMessages, kernel, functionCollection, chatRequestSettings, cancellationToken).ConfigureAwait(false);
+                returnMessages.Messages.AddRange(newMesages.Messages);
             }
         }
 
-        return firstChatMessage.Content;
+        return returnMessages;
     }
 }

--- a/dotnet/src/Connectors/Connectors.AI.OpenAI/ChatCompletionExtensions.cs
+++ b/dotnet/src/Connectors/Connectors.AI.OpenAI/ChatCompletionExtensions.cs
@@ -1,0 +1,60 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.SemanticKernel.Connectors.AI.OpenAI.AzureSdk;
+using Microsoft.SemanticKernel.Orchestration;
+using Microsoft.SemanticKernel.SkillDefinition;
+
+#pragma warning disable IDE0130 // Namespace does not match folder structure
+namespace Microsoft.SemanticKernel.AI.ChatCompletion;
+#pragma warning restore IDE0130 // Namespace does not match folder structure
+
+/// <summary>
+/// Provides extension methods for the IChatCompletion interface.
+/// </summary>
+public static class ChatCompletionExtensions
+{
+    /// <summary>
+    /// Generates a new chat message asynchronously using Functions.
+    /// </summary>
+    /// <param name="chatCompletion">The target IChatCompletion interface to extend.</param>
+    /// <param name="chat">The chat history.</param>
+    /// <param name="kernel">The kernel to use for function execution.</param>
+    /// <param name="requestSettings">The AI request settings (optional).</param>
+    /// <param name="cancellationToken">The asynchronous cancellation token (optional).</param>
+    /// <remarks>This extension does not support multiple prompt results (only the first will be returned).</remarks>
+    /// <returns>A task representing the generated chat message in string format.</returns>
+    public static async Task<string> GenerateMessageWithFunctionsAsync(
+        this IChatCompletion chatCompletion,
+        ChatHistory chat,
+        IKernel kernel,
+        ChatRequestSettings? requestSettings = null,
+        CancellationToken cancellationToken = default)
+    {
+        IReadOnlySkillCollection skillCollection = kernel.Skills;
+        OpenAIChatRequestSettings chatRequestSettings = requestSettings as OpenAIChatRequestSettings ?? new();
+        chatRequestSettings.Functions = skillCollection.GetFunctionsView().ToOpenAIFunctions();
+
+        var chatResults = await chatCompletion.GetChatCompletionsAsync(chat, chatRequestSettings, cancellationToken).ConfigureAwait(false);
+        var firstChatMessage = await chatResults[0].GetChatMessageAsync(cancellationToken).ConfigureAwait(false);
+
+        OpenAIFunctionResult? functionResult = chatResults[0].GetFunctionResult();
+        if (functionResult is not null)
+        {
+            if (skillCollection.TryGetFunction(functionResult.PluginName, functionResult.FunctionName, out var function))
+            {
+                ContextVariables context = new();
+                foreach (var parameter in functionResult.Parameters)
+                {
+                    // Add parameter to context
+                    context.Set(parameter.Key, parameter.Value.ToString());
+                }
+
+                return (await kernel.RunAsync(function, context, cancellationToken).ConfigureAwait(false)).Result;
+            }
+        }
+
+        return firstChatMessage.Content;
+    }
+}

--- a/dotnet/src/Connectors/Connectors.AI.OpenAI/ChatCompletionExtensions.cs
+++ b/dotnet/src/Connectors/Connectors.AI.OpenAI/ChatCompletionExtensions.cs
@@ -37,6 +37,7 @@ public static class ChatCompletionExtensions
         ChatHistory returnMessages = chat;
         IReadOnlyFunctionCollection functionCollection = kernel.Functions;
         OpenAIRequestSettings chatRequestSettings = requestSettings as OpenAIRequestSettings ?? new();
+        chatRequestSettings.FunctionCall = OpenAIRequestSettings.FunctionCallAuto;
         chatRequestSettings.Functions = functionCollection.GetFunctionViews().Select(functionView => functionView.ToOpenAIFunction()).ToList();
 
         var chatMessages = await chatCompletion.GenerateChatHistoryWithFunctionsAsync(chat, kernel, functionCollection, chatRequestSettings, cancellationToken).ConfigureAwait(false);
@@ -54,7 +55,8 @@ public static class ChatCompletionExtensions
     {
         ChatHistory returnMessages = chat;
         var chatResults = await chatCompletion.GetChatCompletionsAsync(chat, chatRequestSettings, cancellationToken).ConfigureAwait(false);
-        var firstChatMessage = await chatResults[0].GetChatMessageAsync(cancellationToken).ConfigureAwait(false);
+        var firstChatMessage = await chatResults[0].GetChatMessageAsync(cancellationToken).ConfigureAwait(false);// as SKChatMessage;
+        // firstChatMessage?.
         returnMessages.Messages.Add(firstChatMessage);
 
         OpenAIFunctionResponse? functionResponse = chatResults[0].GetFunctionResponse();

--- a/dotnet/src/SemanticKernel.Abstractions/AI/ChatCompletion/AuthorRole.cs
+++ b/dotnet/src/SemanticKernel.Abstractions/AI/ChatCompletion/AuthorRole.cs
@@ -32,6 +32,10 @@ public readonly struct AuthorRole : IEquatable<AuthorRole>
     public static readonly AuthorRole Tool = new("tool");
 
     /// <summary>
+    /// The role that provides function call responses for chat completions.
+    public static readonly AuthorRole Function = new("function");
+
+    /// <summary>
     /// Gets the label associated with this AuthorRole.
     /// </summary>
     /// <remarks>

--- a/dotnet/src/SemanticKernel.Abstractions/AI/ChatCompletion/ChatHistory.cs
+++ b/dotnet/src/SemanticKernel.Abstractions/AI/ChatCompletion/ChatHistory.cs
@@ -18,6 +18,20 @@ public class ChatHistory : List<ChatMessageBase>
         }
     }
 
+    // two *new* types of messages, assistant function and function result|response
+    // assistant function has null 'content' and non-null 'function_call'
+    // function result has new name and non-null 'content'
+
+    private sealed class ChatFunctionRequestMessage : ChatMessageBase
+    {
+        public ChatFunctionRequestMessage(string function_call) : base(AuthorRole.Assistant, null)
+        {
+            this.FunctionCall = function_call;
+        }
+
+        public string FunctionCall { get; }
+    }
+
     /// <summary>
     /// List of messages in the chat
     /// </summary>
@@ -42,6 +56,11 @@ public class ChatHistory : List<ChatMessageBase>
     public void InsertMessage(int index, AuthorRole authorRole, string content)
     {
         this.Insert(index, new ChatMessage(authorRole, content));
+    }
+
+    public void AddFunctionMessage(string content, string function)
+    {
+        this.Add(new ChatFunctionMessage(content, function));
     }
 
     /// <summary>

--- a/dotnet/src/SemanticKernel.Abstractions/AI/ChatCompletion/ChatMessageBase.cs
+++ b/dotnet/src/SemanticKernel.Abstractions/AI/ChatCompletion/ChatMessageBase.cs
@@ -15,14 +15,14 @@ public abstract class ChatMessageBase
     /// <summary>
     /// Content of the message
     /// </summary>
-    public string Content { get; set; }
+    public string? Content { get; set; }
 
     /// <summary>
     /// Creates a new instance of the <see cref="ChatMessageBase"/> class
     /// </summary>
     /// <param name="role">Role of the author of the message</param>
     /// <param name="content">Content of the message</param>
-    protected ChatMessageBase(AuthorRole role, string content)
+    protected ChatMessageBase(AuthorRole role, string? content)
     {
         this.Role = role;
         this.Content = content;


### PR DESCRIPTION
This commit refactors the OpenAI function calling in the Example58_OpenAIFunctionCalling.cs file by introducing a new method CompleteChatWithFunctionsManuallyAsync. It also adds a new extension method GenerateMessageWithFunctionsAsync in the
ChatCompletionExtensions.cs file to generate chat messages using Functions. The changes improve code organization and provide a more convenient way to generate chat messages with Functions.

### Motivation and Context

<!-- Thank you for your contribution to the semantic-kernel repo!
Please help reviewers and future users, providing the following information:
  1. Why is this change required?
  2. What problem does it solve?
  3. What scenario does it contribute to?
  4. If it fixes an open issue, please link to the issue here.
-->

### Description

<!-- Describe your changes, the overall approach, the underlying design.
     These notes will help understanding how your code works. Thanks! -->

### Contribution Checklist

<!-- Before submitting this PR, please make sure: -->

- [ ] The code builds clean without any errors or warnings
- [ ] The PR follows the [SK Contribution Guidelines](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md) and the [pre-submission formatting script](https://github.com/microsoft/semantic-kernel/blob/main/CONTRIBUTING.md#development-scripts) raises no violations
- [ ] All unit tests pass, and I have added new tests where possible
- [ ] I didn't break anyone :smile:
